### PR TITLE
Build preview images from `preview/*` branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ci-docker-builder
 
-This repository hosts a script that can be used to build Docker images during the execution on **Travis** or **CircleCI**
-and push the result to Docker Hub.
+This repository hosts a script that can be used to build Docker images during the execution on **Travis**, **CircleCI**
+or **Github Actions** and push the result to Docker Hub.
 
 The **name** of the image and the **repository** are set through environment variables that must be set on each environment.
 
@@ -88,6 +88,29 @@ workflows:
               only: /.*/
             tags:
               only: /.*/
+```
+
+### Github Actions
+
+Add a workflow like this in a `.github/workflows/build.yml` file to let the script decide when to build or not:
+
+```yaml
+name: Build & Push Docker Image
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # needs: test # you can declare a `test` job and uncomment this to test the app before building
+    env:
+      DOCKER_REPOSITORY: 'dockerhub_org/dockerhub_repo'
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image & push to Docker Hub
+        run: ./build.sh
 ```
 
 ## Functions

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ application (for example in the footer).
 ||`release/x.y`|`x.y-dev-rrrrrrr (build nnn)`|`x.y-dev`||
 ||`master`|`dev-rrrrrrr (build nnn)`|`dev`||
 ||`master` (called with **latest** flag)|`rrrrrrr (build nnn)`|`latest`||
+||`preview/some-description`|`some-description-rrrrrrr (build nnn)`|`some-description`||
 
 ## Usage
 

--- a/build.sh
+++ b/build.sh
@@ -65,6 +65,11 @@ dockerSetup() {
         VERSION="${BRANCH##release/}-dev-${COMMIT::7} (build $BUILD_NUMBER)"
         DOCKER_TAG="${BRANCH##release/}-dev"
         ;;
+
+      preview/*)
+        VERSION="${BRANCH##preview/}-${COMMIT::7} (build $BUILD_NUMBER)"
+        DOCKER_TAG="${BRANCH##preview/}"
+        ;;
     esac
   fi
 

--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -155,5 +155,30 @@ testStack() {
   assertNull "${DOCKER_CALLS[5]}"
 }
 
+testPreviewBranch() {
+  branch "preview/my-feature"
+  dockerSetup > /dev/null
+
+  assertEquals "my-feature-0b5a2c5 (build 123)" "$VERSION"
+  assertEquals "my-feature" "$DOCKER_TAG"
+  assertNull "$EXTRA_DOCKER_TAG"
+  assertEquals "login -u user -p pass registry" "${DOCKER_CALLS[0]}"
+  assertNull "${DOCKER_CALLS[1]}"
+}
+
+testBuildAndPushPreviewBranch() {
+  branch "preview/my-feature"
+  dockerSetup > /dev/null
+  dockerBuildAndPush > /dev/null
+
+  assertEquals "my-feature-0b5a2c5 (build 123)" "$VERSION"
+  assertEquals "my-feature" "$DOCKER_TAG"
+  assertNull "$EXTRA_DOCKER_TAG"
+  assertEquals "login -u user -p pass registry" "${DOCKER_CALLS[0]}"
+  assertEquals "build -t repository:my-feature ." "${DOCKER_CALLS[1]}"
+  assertEquals "push repository:my-feature" "${DOCKER_CALLS[2]}"
+  assertNull "${DOCKER_CALLS[3]}"
+}
+
 SHUNIT_PARENT="test-suite.sh"
 . ./shunit2


### PR DESCRIPTION
From time to time we need to build images with a feature preview to test in an staging environment. This PR allows us to push a branch named `preview/some-description` in order to build and push an image with the `some-description` tag.

It's up to the user to check for name colisions - ie, if they push a `preview/latest` branch.