### PR TITLE
Add support for main branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ application (for example in the footer).
 |`x.y`||`x.y (build nnn)`|`x.y`||
 |`x.y.z`||`x.y.z (build nnn)`|`x.y.z`|`x.y`|
 ||`release/x.y`|`x.y-dev-rrrrrrr (build nnn)`|`x.y-dev`||
-||`master`|`dev-rrrrrrr (build nnn)`|`dev`||
-||`master` (called with **latest** flag)|`rrrrrrr (build nnn)`|`latest`||
+||`master` or `main`|`dev-rrrrrrr (build nnn)`|`dev`||
+||`master` or `main` (called with **latest** flag)|`rrrrrrr (build nnn)`|`latest`||
 ||`preview/some-description`|`some-description-rrrrrrr (build nnn)`|`some-description`||
 
 ## Usage
@@ -120,7 +120,7 @@ jobs:
 Prepares the environment to build the Docker image. After executing this function, the environment
 variables `VERSION`, `DOCKER_TAG` and `EXTRA_DOCKER_TAG` will be set.
 
-The optinal `latest` flag will set the `DOCKER_TAG` to "latest". This is useful for projects using continuous delivery of the master branch.
+The optinal `latest` flag will set the `DOCKER_TAG` to "latest". This is useful for projects using continuous delivery of the main branch.
 
 Also it will login to the Docker registry using `docker login` and the environment variables
 `DOCKER_USER`, `DOCKER_PASS` and `DOCKER_REGISTRY` (optional).

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ dockerSetup() {
     fi
   elif [[ -n "$BRANCH" ]]; then
     case $BRANCH in
-      master)
+      master|main)
         case $1 in
           latest)
             VERSION="${COMMIT::7} (build $BUILD_NUMBER)"

--- a/test/test-suite.sh
+++ b/test/test-suite.sh
@@ -66,8 +66,31 @@ testMasterBranch() {
   assertNull "${DOCKER_CALLS[1]}"
 }
 
+testMainBranch() {
+  branch "main"
+  dockerSetup > /dev/null
+
+  assertEquals "dev-0b5a2c5 (build 123)" "$VERSION"
+  assertEquals "dev" "$DOCKER_TAG"
+  assertNull "$EXTRA_DOCKER_TAG"
+  assertEquals "login -u user -p pass registry" "${DOCKER_CALLS[0]}"
+  assertNull "${DOCKER_CALLS[1]}"
+}
+
 testMasterBranchAsLatest() {
   branch "master"
+  dockerSetup latest
+
+  assertEquals "0b5a2c5 (build 123)" "$VERSION"
+  assertEquals "latest" "$DOCKER_TAG"
+  assertNull "$EXTRA_DOCKER_TAG"
+  assertEquals "login -u user -p pass registry" "${DOCKER_CALLS[0]}"
+  assertNull "${DOCKER_CALLS[1]}"
+}
+
+
+testMainBranchAsLatest() {
+  branch "main"
   dockerSetup latest
 
   assertEquals "0b5a2c5 (build 123)" "$VERSION"


### PR DESCRIPTION
GitHub's new repos are created with `main` acting as what was formerly the `master` branch (see lengthy info [here](https://github.com/github/renaming#:~:text=The%20default%20branch%20name%20for%20new%20repositories%20is%20now%20main,%2Fsettings%2Frepository%2Ddefaults%20page)). This already impacts a few repos for recent projects throughout Manas.

_Hopefully_ this PR adds support for that.